### PR TITLE
🛡️ Sentinel: [security improvement] Add HTTP security headers

### DIFF
--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -1,0 +1,46 @@
+import pytest
+import os
+import tempfile
+import history_manager
+from webapp import create_app
+
+@pytest.fixture
+def app_instance(monkeypatch):
+    """Fixture that creates a Flask app instance with a temporary history database."""
+    # Create a temporary database for history
+    db_fd, db_path = tempfile.mkstemp()
+    monkeypatch.setattr(history_manager, 'DB_FILE', db_path)
+
+    app = create_app({
+        'TESTING': True,
+        'WTF_CSRF_ENABLED': False,
+        'SECRET_KEY': 'test-key'
+    })
+
+    yield app
+
+    os.close(db_fd)
+    os.unlink(db_path)
+
+@pytest.fixture
+def client(app_instance):
+    """Fixture that provides a test client for the app."""
+    with app_instance.test_client() as client:
+        yield client
+
+def test_security_headers_presence(client):
+    """Test that security headers are present in the response."""
+    response = client.get('/')
+    assert response.status_code == 200
+
+    headers = response.headers
+
+    # Verify that security headers are correctly set
+    assert 'Content-Security-Policy' in headers
+    assert "default-src 'self'" in headers['Content-Security-Policy']
+    assert 'X-Content-Type-Options' in headers
+    assert headers['X-Content-Type-Options'] == 'nosniff'
+    assert 'X-Frame-Options' in headers
+    assert headers['X-Frame-Options'] == 'SAMEORIGIN'
+    assert 'Referrer-Policy' in headers
+    assert headers['Referrer-Policy'] == 'strict-origin-when-cross-origin'

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -1,26 +1,28 @@
-import pytest
 import os
 import tempfile
+
+import pytest
+
 import history_manager
 from webapp import create_app
+
 
 @pytest.fixture
 def app_instance(monkeypatch):
     """Fixture that creates a Flask app instance with a temporary history database."""
     # Create a temporary database for history
     db_fd, db_path = tempfile.mkstemp()
-    monkeypatch.setattr(history_manager, 'DB_FILE', db_path)
+    monkeypatch.setattr(history_manager, "DB_FILE", db_path)
 
-    app = create_app({
-        'TESTING': True,
-        'WTF_CSRF_ENABLED': False,
-        'SECRET_KEY': 'test-key'
-    })
+    app = create_app(
+        {"TESTING": True, "WTF_CSRF_ENABLED": False, "SECRET_KEY": "test-key"}
+    )
 
     yield app
 
     os.close(db_fd)
     os.unlink(db_path)
+
 
 @pytest.fixture
 def client(app_instance):
@@ -28,19 +30,20 @@ def client(app_instance):
     with app_instance.test_client() as client:
         yield client
 
+
 def test_security_headers_presence(client):
     """Test that security headers are present in the response."""
-    response = client.get('/')
+    response = client.get("/")
     assert response.status_code == 200
 
     headers = response.headers
 
     # Verify that security headers are correctly set
-    assert 'Content-Security-Policy' in headers
-    assert "default-src 'self'" in headers['Content-Security-Policy']
-    assert 'X-Content-Type-Options' in headers
-    assert headers['X-Content-Type-Options'] == 'nosniff'
-    assert 'X-Frame-Options' in headers
-    assert headers['X-Frame-Options'] == 'SAMEORIGIN'
-    assert 'Referrer-Policy' in headers
-    assert headers['Referrer-Policy'] == 'strict-origin-when-cross-origin'
+    assert "Content-Security-Policy" in headers
+    assert "default-src 'self'" in headers["Content-Security-Policy"]
+    assert "X-Content-Type-Options" in headers
+    assert headers["X-Content-Type-Options"] == "nosniff"
+    assert "X-Frame-Options" in headers
+    assert headers["X-Frame-Options"] == "SAMEORIGIN"
+    assert "Referrer-Policy" in headers
+    assert headers["Referrer-Policy"] == "strict-origin-when-cross-origin"

--- a/webapp.py
+++ b/webapp.py
@@ -29,6 +29,15 @@ def create_app(test_config=None):
 
     csrf.init_app(app)
 
+    @app.after_request
+    def set_security_headers(response):
+        """Sets security headers for every response."""
+        response.headers['Content-Security-Policy'] = "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'"
+        response.headers['X-Content-Type-Options'] = 'nosniff'
+        response.headers['X-Frame-Options'] = 'SAMEORIGIN'
+        response.headers['Referrer-Policy'] = 'strict-origin-when-cross-origin'
+        return response
+
     # Note: Template filters, error handlers, and routes are registered here
     # to avoid import-time side effects (like DB initialization).
 

--- a/webapp.py
+++ b/webapp.py
@@ -1,16 +1,20 @@
 """
-Flask web application serving the whoistel user interface, 
+Flask web application serving the whoistel user interface,
 handling number lookups and community spam reporting.
 """
+
 import os
 from datetime import datetime
-from flask import Flask, render_template, request, redirect, url_for, flash, g
+
+from flask import Flask, flash, g, redirect, render_template, request, url_for
 from flask_wtf import CSRFProtect
+
 import history_manager
 import whoistel
 
 csrf = CSRFProtect()
 MAX_COMMENT_LENGTH = 1024
+
 
 def create_app(test_config=None):
     """
@@ -18,12 +22,12 @@ def create_app(test_config=None):
     Initializes configuration, CSRF protection, and database schema.
     """
     app = Flask(__name__)
-    
+
     if test_config:
         app.config.update(test_config)
     else:
-        app.config['SECRET_KEY'] = os.environ.get('SECRET_KEY')
-        if not app.config['SECRET_KEY']:
+        app.config["SECRET_KEY"] = os.environ.get("SECRET_KEY")
+        if not app.config["SECRET_KEY"]:
             # In production, this is mandatory.
             raise ValueError("Environment variable SECRET_KEY must be set.")
 
@@ -32,17 +36,19 @@ def create_app(test_config=None):
     @app.after_request
     def set_security_headers(response):
         """Sets security headers for every response."""
-        response.headers['Content-Security-Policy'] = "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'"
-        response.headers['X-Content-Type-Options'] = 'nosniff'
-        response.headers['X-Frame-Options'] = 'SAMEORIGIN'
-        response.headers['Referrer-Policy'] = 'strict-origin-when-cross-origin'
+        response.headers["Content-Security-Policy"] = (
+            "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'"
+        )
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["X-Frame-Options"] = "SAMEORIGIN"
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
         return response
 
     # Note: Template filters, error handlers, and routes are registered here
     # to avoid import-time side effects (like DB initialization).
 
-    @app.template_filter('format_datetime')
-    def format_datetime(value, format='%d/%m/%Y %H:%M'):
+    @app.template_filter("format_datetime")
+    def format_datetime(value, format="%d/%m/%Y %H:%M"):
         """Jinja2 filter to format datetime objects or ISO strings."""
         if not value:
             return ""
@@ -51,14 +57,15 @@ def create_app(test_config=None):
         if isinstance(value, datetime):
             dt_obj = value
         elif isinstance(value, str):
-            for fmt in ('%Y-%m-%d %H:%M:%S', '%Y-%m-%d'):
+            for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%d"):
                 try:
                     dt_obj = datetime.strptime(value, fmt)
                     break
                 except ValueError:
                     pass
             else:
-                app.logger.warning(f"Could not parse datetime string: '{value}'")
+                app.logger.warning(
+                    f"Could not parse datetime string: '{value}'")
 
         return dt_obj.strftime(format) if dt_obj else ""
 
@@ -72,7 +79,7 @@ def create_app(test_config=None):
             db = connect_func()
             setattr(g, name, db)
             # Scalable registry for teardown
-            if not hasattr(g, 'db_connections'):
+            if not hasattr(g, "db_connections"):
                 g.db_connections = []
             g.db_connections.append(db)
         return db
@@ -80,98 +87,132 @@ def create_app(test_config=None):
     @app.teardown_appcontext
     def close_dbs(_error):
         """Closes all database connections at the end of the request."""
-        for conn in getattr(g, 'db_connections', []):
+        for conn in getattr(g, "db_connections", []):
             try:
                 conn.close()
             except Exception:
-                app.logger.error("Error closing database connection during teardown.")
+                app.logger.error(
+                    "Error closing database connection during teardown.")
 
     @app.errorhandler(whoistel.DatabaseError)
     def handle_db_error(e):
         """Global handler for DatabaseError exceptions."""
         app.logger.error(f"Database error: {e}")
-        return render_template('error.html', message="Database error occurred"), 500
+        return render_template("error.html", message="Database error occurred"), 500
 
-    @app.route('/', methods=['GET'])
+    @app.route("/", methods=["GET"])
     def index():
         """Renders the landing page with the search form."""
-        return render_template('index.html')
+        return render_template("index.html")
 
-    @app.route('/check', methods=['POST'])
+    @app.route("/check", methods=["POST"])
     def check():
         """Validates the input number and redirects to the view page."""
-        raw_tel = request.form.get('number')
+        raw_tel = request.form.get("number")
         if not raw_tel:
             flash("Veuillez saisir un numéro.", "error")
-            return redirect(url_for('index'))
+            return redirect(url_for("index"))
 
         tel = whoistel.clean_phone_number(raw_tel)
         if not whoistel.is_valid_phone_format(tel):
-            flash("Le numéro de téléphone est invalide. Il doit contenir exactement 10 chiffres (ex: 0123456789).", "error")
-            return redirect(url_for('index'))
+            flash(
+                "Le numéro de téléphone est invalide. Il doit contenir exactement 10 chiffres (ex: 0123456789).",
+                "error",
+            )
+            return redirect(url_for("index"))
 
-        return redirect(url_for('view_number', number=tel))
+        return redirect(url_for("view_number", number=tel))
 
-    @app.route('/view/<number>', methods=['GET'])
+    @app.route("/view/<number>", methods=["GET"])
     def view_number(number):
         """Displays information and history for a specific phone number."""
         cleaned_number = whoistel.clean_phone_number(number)
-        
+
         if not whoistel.is_valid_phone_format(cleaned_number):
-            return render_template('error.html', message="Le format du numéro est invalide."), 400
+            return (
+                render_template(
+                    "error.html", message="Le format du numéro est invalide."
+                ),
+                400,
+            )
 
         if cleaned_number != number:
-            return redirect(url_for('view_number', number=cleaned_number))
+            return redirect(url_for("view_number", number=cleaned_number))
 
-        conn = _get_db('main_db', whoistel.setup_db_connection)
+        conn = _get_db("main_db", whoistel.setup_db_connection)
         result = whoistel.get_full_info(conn, cleaned_number)
-        spam_count = history_manager.get_spam_count(cleaned_number, conn=_get_db('history_db', history_manager.get_db_connection))
+        spam_count = history_manager.get_spam_count(
+            cleaned_number,
+            conn=_get_db("history_db", history_manager.get_db_connection),
+        )
 
-        return render_template('result.html', result=result, spam_count=spam_count, number=cleaned_number)
+        return render_template(
+            "result.html", result=result, spam_count=spam_count, number=cleaned_number
+        )
 
-    @app.route('/report', methods=['POST'])
+    @app.route("/report", methods=["POST"])
     def report():
         """Handles submission of spam reports and comments."""
-        number = whoistel.clean_phone_number(request.form.get('number'))
+        number = whoistel.clean_phone_number(request.form.get("number"))
         if not number:
-             flash("Veuillez saisir un numéro.", "error")
-             return redirect(url_for('index'))
+            flash("Veuillez saisir un numéro.", "error")
+            return redirect(url_for("index"))
 
         # Validate number format early to fail fast
         if not whoistel.is_valid_phone_format(number):
-            flash("Le format du numéro de téléphone est invalide pour un signalement.", "error")
-            return redirect(url_for('index'))
+            flash(
+                "Le format du numéro de téléphone est invalide pour un signalement.",
+                "error",
+            )
+            return redirect(url_for("index"))
 
-        date = request.form.get('date')
-        is_spam = request.form.get('is_spam') == 'on'
-        
-        raw_comment = (request.form.get('comment') or '').strip()
+        date = request.form.get("date")
+        is_spam = request.form.get("is_spam") == "on"
+
+        raw_comment = (request.form.get("comment") or "").strip()
         if len(raw_comment) > MAX_COMMENT_LENGTH:
-            flash(f"Votre commentaire a été tronqué à {MAX_COMMENT_LENGTH} caractères.", "info")
+            flash(
+                f"Votre commentaire a été tronqué à {MAX_COMMENT_LENGTH} caractères.",
+                "info",
+            )
         comment = raw_comment[:MAX_COMMENT_LENGTH]
 
         if date:
             try:
-                datetime.strptime(date, '%Y-%m-%d')
+                datetime.strptime(date, "%Y-%m-%d")
             except ValueError:
-                flash(f"Le format de la date '{date}' est invalide (attendu: AAAA-MM-JJ).", "error")
-                return redirect(url_for('view_number', number=number))
+                flash(
+                    f"Le format de la date '{date}' est invalide (attendu: AAAA-MM-JJ).",
+                    "error",
+                )
+                return redirect(url_for("view_number", number=number))
         else:
             date = None
 
         if not is_spam and not comment and not date:
-            flash("Veuillez cocher la case spam, ajouter un commentaire ou une date.", "error")
-            return redirect(url_for('view_number', number=number))
+            flash(
+                "Veuillez cocher la case spam, ajouter un commentaire ou une date.",
+                "error",
+            )
+            return redirect(url_for("view_number", number=number))
 
-        history_manager.add_report(number, date, is_spam, comment, conn=_get_db('history_db', history_manager.get_db_connection))
+        history_manager.add_report(
+            number,
+            date,
+            is_spam,
+            comment,
+            conn=_get_db("history_db", history_manager.get_db_connection),
+        )
         flash("Signalement enregistré.", "success")
-        return redirect(url_for('view_number', number=number))
+        return redirect(url_for("view_number", number=number))
 
-    @app.route('/history', methods=['GET'])
+    @app.route("/history", methods=["GET"])
     def history():
         """Displays the list of recent spam reports."""
-        reports = history_manager.get_recent_reports(conn=_get_db('history_db', history_manager.get_db_connection))
-        return render_template('history.html', reports=reports)
+        reports = history_manager.get_recent_reports(
+            conn=_get_db("history_db", history_manager.get_db_connection)
+        )
+        return render_template("history.html", reports=reports)
 
     # Initialize history database schema if needed
     with app.app_context():
@@ -179,7 +220,8 @@ def create_app(test_config=None):
 
     return app
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     app = create_app()
-    debug_mode = os.environ.get('FLASK_DEBUG', '0') == '1'
-    app.run(debug=debug_mode, host='127.0.0.1', port=5000)
+    debug_mode = os.environ.get("FLASK_DEBUG", "0") == "1"
+    app.run(debug=debug_mode, host="127.0.0.1", port=5000)


### PR DESCRIPTION
### **User description**
Added standard HTTP security headers (CSP, X-Frame-Options, etc.) to the Flask application to improve security posture. Included a new test case to verify their presence.

---
*PR created automatically by Jules for task [6540273100987704073](https://jules.google.com/task/6540273100987704073) started by @sheepdestroyer*


___

### **PR Type**
Enhancement


___

### **Description**
- Add HTTP security headers to Flask application responses

- Implement Content-Security-Policy, X-Content-Type-Options, X-Frame-Options, Referrer-Policy headers

- Add comprehensive test suite verifying security headers presence and values


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Flask App"] -->|after_request hook| B["set_security_headers"]
  B -->|inject headers| C["HTTP Response"]
  D["Test Suite"] -->|verify| C
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>webapp.py</strong><dd><code>Add security headers middleware to Flask app</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

webapp.py

<ul><li>Added <code>after_request</code> hook <code>set_security_headers()</code> to inject security <br>headers into all responses<br> <li> Sets Content-Security-Policy with default-src 'self' and unsafe-inline <br>for scripts/styles<br> <li> Sets X-Content-Type-Options to 'nosniff' to prevent MIME type sniffing<br> <li> Sets X-Frame-Options to 'SAMEORIGIN' to prevent clickjacking<br> <li> Sets Referrer-Policy to 'strict-origin-when-cross-origin' for referrer <br>control</ul>


</details>


  </td>
  <td><a href="https://github.com/sheepdestroyer/whoistel/pull/50/files#diff-52e578e35c9686d4b1dc4ae0259183c3a08fab21de0114c75e6c705a4ea18367">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_security_headers.py</strong><dd><code>Add security headers verification test suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_security_headers.py

<ul><li>Created new test file with pytest fixtures for app instance and test <br>client<br> <li> Added <code>test_security_headers_presence()</code> to verify all four security <br>headers are present<br> <li> Validates Content-Security-Policy contains "default-src 'self'"<br> <li> Validates X-Content-Type-Options equals 'nosniff', X-Frame-Options <br>equals 'SAMEORIGIN', and Referrer-Policy equals <br>'strict-origin-when-cross-origin'</ul>


</details>


  </td>
  <td><a href="https://github.com/sheepdestroyer/whoistel/pull/50/files#diff-5558125bd2f689837f124c37d75e474c6362066cea6080d327199599c635eaca">+46/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive security headers to all HTTP responses, including Content-Security-Policy, X-Content-Type-Options (nosniff), X-Frame-Options (SAMEORIGIN), and Referrer-Policy (strict-origin-when-cross-origin).

* **Tests**
  * Introduced test coverage validating security headers are present and correctly configured on all responses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->